### PR TITLE
Make all work

### DIFF
--- a/Dockerfile.worker-debian
+++ b/Dockerfile.worker-debian
@@ -36,4 +36,4 @@ COPY --from=build /opt /opt
 
 WORKDIR /app
 
-CMD node /app/src/worker/index.js
+CMD npm run start:worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,18 +9,19 @@ services:
       - 3000:3000
     volumes:
       - .:/app
-    links:
-      - rabbitmq:rabbitmq-service
-      - mongodb:mongodb-service
+      - app-node-modules:/app/node_modules
     environment:
       - AMQP_APP_ID=sandbox
-      - BROKER_URL=amqp://guest:guest@rabbitmq-service:5672
+      - BROKER_URL=amqp://guest:guest@rabbitmq:5672
       - INCOMING_QUEUE=attach-to-tangle
       - COMPLETED_QUEUE=attach-complete
       - UPDATE_QUEUE=attach-progress
-      - MONGO_CONN=mongodb://localhost:27017/sandbox
-      - IRI_HOST=https://nodes.iota.cafe
+      - MONGO_CONN=mongodb://mongodb:27017/sandbox
+      - IRI_HOST=https://nodes.devnet.iota.org
       - IRI_PORT=443
+      - MWM_LIMIT=9
+      - NODE_ENV=development
+      - SESSION_SECRET=PutTheRandomSecreteHere
     depends_on:
       - rabbitmq
       - mongodb
@@ -28,14 +29,12 @@ services:
   worker:
     build:
       context: .
-      dockerfile: Dockerfile.worker
+      dockerfile: Dockerfile.worker-debian
     volumes:
       - .:/app
-    links:
-      - rabbitmq:rabbitmq-service
-      - mongodb:mongodb-service
+      - worker-node-modules:/app/node_modules
     environment:
-      - BROKER_URL=amqp://guest:guest@rabbitmq-service:5672
+      - BROKER_URL=amqp://guest:guest@rabbitmq:5672
       - INCOMING_QUEUE=attach-to-tangle
       - COMPLETED_QUEUE=attach-complete
       - UPDATE_QUEUE=attach-progress
@@ -52,3 +51,7 @@ services:
     image: mongo
     ports:
       - 27017:27017
+
+volumes:
+  app-node-modules:
+  worker-node-modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - COMPLETED_QUEUE=attach-complete
       - UPDATE_QUEUE=attach-progress
       - CCURL_PATH=/opt
+      - DAEMON_MODE=true
     depends_on:
       - api
 

--- a/src/server/commands.js
+++ b/src/server/commands.js
@@ -1,7 +1,7 @@
-const amqp = require('amqplib');
 const IOTA = require('iota.lib.js');
 
 const { job } = require('../common/db');
+const { connect } = require('./rabbit');
 const log = require('../common/logging');
 const { asBuffer } = require('../common/utils');
 
@@ -18,7 +18,7 @@ const attachToTangle = async (req, callback) => {
         return;
     }
 
-    const { channel } = req.rabbit;
+    const { channel } = await connect;
 
     let messageId;
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -35,8 +35,6 @@ app.use(
     })
 );
 
-app.use(mq.middleware());
-
 app.post('/api/v1/commands', rateLimiter(), apiCommands);
 
 app.get('/api/v1/jobs/:jobId', async (req, res) => {

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -157,6 +157,10 @@ async function listen(timeout) {
 
     await channel.assertQueue(INCOMING_QUEUE);
 
+    channel.on('error', () => {
+        listen(timeout);
+    });
+
     channel.consume(INCOMING_QUEUE, msg => {
         logInfo(msg.properties.messageId, infoCodes.RECEIVED);
 

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -184,4 +184,12 @@ async function listen(timeout) {
     log.listen(INCOMING_QUEUE, `Timeout set to ${timeout} seconds`);
 }
 
-listen(parseInt(JOB_TIMEOUT || DEFAULT_JOB_TIMEOUT, 10));
+const listenRabbit = () => {
+    listen(parseInt(JOB_TIMEOUT || DEFAULT_JOB_TIMEOUT, 10))
+        .catch(() => {
+            console.log('Failed to connect rabbit mq, retry in 5 seconds');
+            setTimeout(() => listenRabbit(), 5000);
+        });
+};
+
+listenRabbit();


### PR DESCRIPTION
Server and worker need to retry to connect the rabbit on failure while rabbit needs some time to initialize and setup.

Separate node_modules volumes for worker and api for concurrent build availability.
Fix service names.
Dockerfile.worker-alpine has no amqp-tools package so it does not work.
Add required for api env variable SESSION_SECRET.
Switch api to devnet IRI.